### PR TITLE
Add support for v26 and v27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["examples/*"]
 
 [package]
 name = "opentelemetry_gcloud_monitoring_exporter"
-version = "0.12.0"
+version = "0.13.0"
 description = "Provides support for exporting metrics to Google Cloud Monitoring."
 readme = "README.md"
 keywords = ["opentelemetry", "metrics", "exporter", "gcp", "cloud-monitoring"]
@@ -17,13 +17,22 @@ rust-version = "1.70"
 doctest = false
 
 [features]
-default = ["rt_tokio_opentelemetry_sdk_0_25", "opentelemetry_0_25", "gcp_auth"]
+default = ["rt_tokio_opentelemetry_sdk_0_26", "opentelemetry_0_26", "gcp_auth"]
 # default = ["tokio", "opentelemetry_0_24", "gcp_auth"]
 gcp_auth = ["dep:gcp_auth"]
 tokio = ["dep:tokio"]
 # default = ["rt_tokio_opentelemetry_sdk_0_23", "opentelemetry_0_23", "gcp_auth"]
 # default = ["rt_tokio_opentelemetry_sdk_0_22", "opentelemetry_0_22", "gcp_auth"]
 # default = ["rt_tokio_opentelemetry_sdk_0_21", "opentelemetry_0_21", "gcp_auth"]
+opentelemetry_0_26 = [
+    "opentelemetry_0_26_pkg",
+    "opentelemetry_sdk_0_26_pkg",
+    "opentelemetry_resourcedetector_gcp_rust_0_13_pkg",
+]
+rt_tokio_opentelemetry_sdk_0_26 = [
+    "tokio",
+    "opentelemetry_sdk_0_26_pkg/rt-tokio",
+]
 opentelemetry_0_25 = [
     "opentelemetry_0_25_pkg",
     "opentelemetry_sdk_0_25_pkg",
@@ -90,8 +99,10 @@ opentelemetry_0_23_pkg = { package = "opentelemetry", version = "0.23", features
 opentelemetry_0_24_pkg = { package = "opentelemetry", version = "0.24", features = [
     "metrics",
 ], optional = true }
-
 opentelemetry_0_25_pkg = { package = "opentelemetry", version = "0.25", features = [
+    "metrics",
+], optional = true }
+opentelemetry_0_26_pkg = { package = "opentelemetry", version = "0.26", features = [
     "metrics",
 ], optional = true }
 
@@ -110,11 +121,16 @@ opentelemetry_sdk_0_24_pkg = { package = "opentelemetry_sdk", version = "0.24", 
 opentelemetry_sdk_0_25_pkg = { package = "opentelemetry_sdk", version = "0.25", features = [
     "metrics",
 ], optional = true }
+opentelemetry_sdk_0_26_pkg = { package = "opentelemetry_sdk", version = "0.26", features = [
+    "metrics",
+], optional = true }
+
 opentelemetry_resourcedetector_gcp_rust_0_8_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.8", optional = true }
 opentelemetry_resourcedetector_gcp_rust_0_9_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.9", optional = true }
 opentelemetry_resourcedetector_gcp_rust_0_10_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.10", optional = true }
 opentelemetry_resourcedetector_gcp_rust_0_11_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.11", optional = true }
 opentelemetry_resourcedetector_gcp_rust_0_12_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.12", optional = true }
+opentelemetry_resourcedetector_gcp_rust_0_13_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.13", optional = true }
 
 async-trait = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["examples/*"]
 
 [package]
 name = "opentelemetry_gcloud_monitoring_exporter"
-version = "0.13.0"
+version = "0.14.0"
 description = "Provides support for exporting metrics to Google Cloud Monitoring."
 readme = "README.md"
 keywords = ["opentelemetry", "metrics", "exporter", "gcp", "cloud-monitoring"]
@@ -17,13 +17,23 @@ rust-version = "1.70"
 doctest = false
 
 [features]
-default = ["rt_tokio_opentelemetry_sdk_0_26", "opentelemetry_0_26", "gcp_auth"]
+default = ["rt_tokio_opentelemetry_sdk_0_27", "opentelemetry_0_27", "gcp_auth"]
 # default = ["tokio", "opentelemetry_0_24", "gcp_auth"]
 gcp_auth = ["dep:gcp_auth"]
 tokio = ["dep:tokio"]
 # default = ["rt_tokio_opentelemetry_sdk_0_23", "opentelemetry_0_23", "gcp_auth"]
 # default = ["rt_tokio_opentelemetry_sdk_0_22", "opentelemetry_0_22", "gcp_auth"]
 # default = ["rt_tokio_opentelemetry_sdk_0_21", "opentelemetry_0_21", "gcp_auth"]
+opentelemetry_0_27 = [
+    "opentelemetry_0_27_pkg",
+    "opentelemetry_sdk_0_27_pkg",
+    "opentelemetry_resourcedetector_gcp_rust_0_14_pkg",
+    "dep:tracing",
+]
+rt_tokio_opentelemetry_sdk_0_27 = [
+    "tokio",
+    "opentelemetry_sdk_0_27_pkg/rt-tokio",
+]
 opentelemetry_0_26 = [
     "opentelemetry_0_26_pkg",
     "opentelemetry_sdk_0_26_pkg",
@@ -105,6 +115,9 @@ opentelemetry_0_25_pkg = { package = "opentelemetry", version = "0.25", features
 opentelemetry_0_26_pkg = { package = "opentelemetry", version = "0.26", features = [
     "metrics",
 ], optional = true }
+opentelemetry_0_27_pkg = { package = "opentelemetry", version = "0.27", features = [
+    "metrics",
+], optional = true }
 
 opentelemetry_sdk_0_21_pkg = { package = "opentelemetry_sdk", version = "0.21", features = [
     "metrics",
@@ -124,6 +137,9 @@ opentelemetry_sdk_0_25_pkg = { package = "opentelemetry_sdk", version = "0.25", 
 opentelemetry_sdk_0_26_pkg = { package = "opentelemetry_sdk", version = "0.26", features = [
     "metrics",
 ], optional = true }
+opentelemetry_sdk_0_27_pkg = { package = "opentelemetry_sdk", version = "0.27", features = [
+    "metrics", "spec_unstable_metrics_views",
+], optional = true }
 
 opentelemetry_resourcedetector_gcp_rust_0_8_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.8", optional = true }
 opentelemetry_resourcedetector_gcp_rust_0_9_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.9", optional = true }
@@ -131,6 +147,7 @@ opentelemetry_resourcedetector_gcp_rust_0_10_pkg = { package = "opentelemetry_re
 opentelemetry_resourcedetector_gcp_rust_0_11_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.11", optional = true }
 opentelemetry_resourcedetector_gcp_rust_0_12_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.12", optional = true }
 opentelemetry_resourcedetector_gcp_rust_0_13_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.13", optional = true }
+opentelemetry_resourcedetector_gcp_rust_0_14_pkg = { package = "opentelemetry_resourcedetector_gcp_rust", version = "0.14", optional = true }
 
 async-trait = "0.1"
 
@@ -161,6 +178,7 @@ async-std = { version = "1.13.0", optional = true }
 
 rand = "0.8.5"
 itertools = "0.13.0"
+tracing = { version = "0.1.41", optional = true }
 
 [dependencies.darrentsung_debug_parser]
 version = "0.3.1"

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -22,6 +22,14 @@ use opentelemetry::{
     metrics::{MetricsError, Result as MetricsResult},
 };
 use opentelemetry_resourcedetector_gcp_rust::mapping::get_monitored_resource;
+#[cfg(any(
+    feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
+    feature = "opentelemetry_0_23",
+    feature = "opentelemetry_0_24",
+    feature = "opentelemetry_0_25",
+))]
+use opentelemetry_sdk::metrics::reader::{AggregationSelector, DefaultAggregationSelector};
 use opentelemetry_sdk::metrics::{
     data::{
         ExponentialHistogram as SdkExponentialHistogram, Gauge as SdkGauge,
@@ -29,9 +37,10 @@ use opentelemetry_sdk::metrics::{
         Sum as SdkSum, Temporality,
     },
     exporter::PushMetricsExporter,
-    reader::{AggregationSelector, DefaultAggregationSelector, TemporalitySelector},
+    reader::TemporalitySelector,
     InstrumentKind,
 };
+
 use rand::Rng;
 use std::{
     collections::{HashMap, HashSet},
@@ -165,6 +174,13 @@ impl TemporalitySelector for GCPMetricsExporter {
     }
 }
 
+#[cfg(any(
+    feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
+    feature = "opentelemetry_0_23",
+    feature = "opentelemetry_0_24",
+    feature = "opentelemetry_0_25",
+))]
 impl AggregationSelector for GCPMetricsExporter {
     // TODO: this should ideally be done at SDK level by default
     // without exporters having to do it.
@@ -207,7 +223,7 @@ impl GCPMetricsExporter {
         let unit = metric.unit.as_str().to_string();
         #[cfg(any(feature = "opentelemetry_0_24",))]
         let unit = metric.unit.to_string();
-        #[cfg(any(feature = "opentelemetry_0_25",))]
+        #[cfg(any(feature = "opentelemetry_0_25", feature = "opentelemetry_0_26",))]
         let unit = metric.unit.to_string();
         let mut descriptor = MetricDescriptor {
             r#type: descriptor_type.clone(),

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -17,10 +17,15 @@ use gcloud_sdk::google::{
     },
 };
 use itertools::Itertools;
-use opentelemetry::{
-    global,
-    metrics::{MetricsError, Result as MetricsResult},
-};
+#[cfg(any(
+    feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
+    feature = "opentelemetry_0_23",
+    feature = "opentelemetry_0_24",
+    feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
+))]
+use opentelemetry::metrics::{MetricsError, Result as MetricsResult};
 use opentelemetry_resourcedetector_gcp_rust::mapping::get_monitored_resource;
 #[cfg(any(
     feature = "opentelemetry_0_21",
@@ -30,15 +35,26 @@ use opentelemetry_resourcedetector_gcp_rust::mapping::get_monitored_resource;
     feature = "opentelemetry_0_25",
 ))]
 use opentelemetry_sdk::metrics::reader::{AggregationSelector, DefaultAggregationSelector};
+#[cfg(any(
+    feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
+    feature = "opentelemetry_0_23",
+    feature = "opentelemetry_0_24",
+    feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
+))]
 use opentelemetry_sdk::metrics::{
-    data::{
-        ExponentialHistogram as SdkExponentialHistogram, Gauge as SdkGauge,
-        Histogram as SdkHistogram, Metric as OpentelemetrySdkMetric, ResourceMetrics,
-        Sum as SdkSum, Temporality,
-    },
-    exporter::PushMetricsExporter,
-    reader::TemporalitySelector,
-    InstrumentKind,
+    data::Temporality, exporter::PushMetricsExporter, reader::TemporalitySelector, InstrumentKind,
+};
+
+use opentelemetry_sdk::metrics::data::{
+    ExponentialHistogram as SdkExponentialHistogram, Gauge as SdkGauge, Histogram as SdkHistogram,
+    Metric as OpentelemetrySdkMetric, ResourceMetrics, Sum as SdkSum,
+};
+#[cfg(any(feature = "opentelemetry_0_27",))]
+use opentelemetry_sdk::metrics::{
+    exporter::PushMetricExporter as PushMetricsExporter, MetricError as MetricsError,
+    MetricResult as MetricsResult, Temporality,
 };
 
 use rand::Rng;
@@ -158,6 +174,14 @@ impl GCPMetricsExporter {
     }
 }
 
+#[cfg(any(
+    feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
+    feature = "opentelemetry_0_23",
+    feature = "opentelemetry_0_24",
+    feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
+))]
 impl TemporalitySelector for GCPMetricsExporter {
     // This is matching OTLP exporters delta.
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
@@ -223,7 +247,11 @@ impl GCPMetricsExporter {
         let unit = metric.unit.as_str().to_string();
         #[cfg(any(feature = "opentelemetry_0_24",))]
         let unit = metric.unit.to_string();
-        #[cfg(any(feature = "opentelemetry_0_25", feature = "opentelemetry_0_26",))]
+        #[cfg(any(
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+            feature = "opentelemetry_0_27",
+        ))]
         let unit = metric.unit.to_string();
         let mut descriptor = MetricDescriptor {
             r#type: descriptor_type.clone(),
@@ -299,7 +327,7 @@ impl GCPMetricsExporter {
                 descriptor.metric_kind = MetricKind::Gauge.into();
                 descriptor.value_type = metric_descriptor::ValueType::Double.into();
             } else {
-                global::handle_error(MetricsError::Other(format!(
+                utils::log_warning(MetricsError::Other(format!(
                 "GCPMetricsExporter: Unsupported metric data type, ignoring it for metric with name '{}'", metric.name),
             ));
                 // warning!("Unsupported metric data type, ignoring it");
@@ -314,7 +342,7 @@ impl GCPMetricsExporter {
         let channel = match self.make_chanel().await {
             Ok(channel) => channel,
             Err(err) => {
-                global::handle_error(MetricsError::Other(format!("GCPMetricsExporter: Cant init google services grpc transport channel [Make issue with this case in github repo]: {:?}", err)));
+                utils::log_warning(MetricsError::Other(format!("GCPMetricsExporter: Cant init google services grpc transport channel [Make issue with this case in github repo]: {:?}", err)));
                 return None;
             }
         };
@@ -323,7 +351,7 @@ impl GCPMetricsExporter {
         loop {
             iteration += 1;
             if iteration > 101 {
-                global::handle_error(MetricsError::Other(
+                utils::log_warning(MetricsError::Other(
                     "GCPMetricsExporter: Cant create_metric_descriptor".into(),
                 ));
                 return None;
@@ -342,7 +370,7 @@ impl GCPMetricsExporter {
                     );
                 }
                 Err(err) => {
-                    global::handle_error(MetricsError::Other(format!(
+                    utils::log_warning(MetricsError::Other(format!(
                         "GCPMetricsExporter: cant authorize: {:?}",
                         err
                     )));
@@ -358,7 +386,7 @@ impl GCPMetricsExporter {
                     //     descriptor,
                     //     exc_info=ex,
                     // )
-                    global::handle_error(MetricsError::Other(format!(
+                    utils::log_warning(MetricsError::Other(format!(
                         "GCPMetricsExporter: Retry send create_metric_descriptor: {:?}",
                         err
                     )));
@@ -526,7 +554,7 @@ impl GCPMetricsExporter {
                         ));
                     }
                 } else {
-                    global::handle_error(MetricsError::Other(format!(
+                    utils::log_warning(MetricsError::Other(format!(
                         "GCPMetricsExporter: Unsupported metric data type, ignoring it for metric with name '{}'", metric.name),
                     ));
                 };
@@ -582,7 +610,7 @@ impl GCPMetricsExporter {
                 };
                 let mut msc = MetricServiceClient::new(channel);
                 if let Err(err) = msc.create_time_series(req).await {
-                    global::handle_error(MetricsError::Other(format!(
+                    utils::log_warning(MetricsError::Other(format!(
                         "GCPMetricsExporter: Cant send time series: {:?}",
                         err
                     )));
@@ -597,7 +625,7 @@ impl GCPMetricsExporter {
                             continue;
                         }
                         _ => {
-                            global::handle_error(MetricsError::Other(format!(
+                            utils::log_warning(MetricsError::Other(format!(
                                 "GCPMetricsExporter: Cant send time series: Request: {:?}",
                                 create_time_series_request
                             )));
@@ -635,5 +663,10 @@ impl PushMetricsExporter for GCPMetricsExporter {
         // TracepointState automatically unregisters when dropped
         // https://github.com/microsoft/LinuxTracepoints-Rust/blob/main/eventheader/src/native.rs#L618
         Ok(())
+    }
+
+    #[cfg(any(feature = "opentelemetry_0_27",))]
+    fn temporality(&self) -> Temporality {
+        Temporality::default()
     }
 }

--- a/src/exporter/utils.rs
+++ b/src/exporter/utils.rs
@@ -6,9 +6,20 @@ crate::import_opentelemetry!();
     feature = "opentelemetry_0_24",
     feature = "opentelemetry_0_25",
     feature = "opentelemetry_0_26",
+    feature = "opentelemetry_0_27",
 ))]
 use opentelemetry::KeyValue;
+#[cfg(any(
+    feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
+    feature = "opentelemetry_0_23",
+    feature = "opentelemetry_0_24",
+    feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
+))]
 use opentelemetry::{global, metrics::MetricsError};
+#[cfg(any(feature = "opentelemetry_0_27",))]
+use opentelemetry_sdk::metrics::MetricError as MetricsError;
 
 use opentelemetry_sdk::metrics::data::{
     ExponentialHistogram as SdkExponentialHistogram, Gauge as SdkGauge, Histogram as SdkHistogram,
@@ -16,6 +27,20 @@ use opentelemetry_sdk::metrics::data::{
 };
 use std::any::Any;
 use std::collections::HashSet;
+
+pub(crate) fn log_warning(err: MetricsError) {
+    #[cfg(any(
+        feature = "opentelemetry_0_21",
+        feature = "opentelemetry_0_22",
+        feature = "opentelemetry_0_23",
+        feature = "opentelemetry_0_24",
+        feature = "opentelemetry_0_25",
+        feature = "opentelemetry_0_26",
+    ))]
+    global::handle_error(err);
+    #[cfg(any(feature = "opentelemetry_0_27",))]
+    tracing::warn!("{}", err);
+}
 
 pub(crate) fn get_data_points_attributes_keys(data: &dyn Any) -> HashSet<String> {
     let attributes_keys = if let Some(v) = data.downcast_ref::<SdkHistogram<i64>>() {
@@ -91,7 +116,7 @@ pub(crate) fn get_data_points_attributes_keys(data: &dyn Any) -> HashSet<String>
             .flatten()
             .collect()
     } else {
-        global::handle_error(MetricsError::Other(
+        log_warning(MetricsError::Other(
             "Unsupported metric data type, ignoring it".into(),
         ));
         vec![]
@@ -138,6 +163,7 @@ fn sanitize_string(s: &str) -> String {
     feature = "opentelemetry_0_24",
     feature = "opentelemetry_0_25",
     feature = "opentelemetry_0_26",
+    feature = "opentelemetry_0_27",
 ))]
 pub(crate) fn kv_map_normalize_k_v(kv: &KeyValue) -> (String, String) {
     (
@@ -153,6 +179,7 @@ pub(crate) fn kv_map_normalize_k_v(kv: &KeyValue) -> (String, String) {
     feature = "opentelemetry_0_24",
     feature = "opentelemetry_0_25",
     feature = "opentelemetry_0_26",
+    feature = "opentelemetry_0_27",
 ))]
 pub(crate) fn kv_map_k(kv: &KeyValue) -> String {
     kv.key.to_string()

--- a/src/exporter/utils.rs
+++ b/src/exporter/utils.rs
@@ -5,6 +5,7 @@ crate::import_opentelemetry!();
     // feature = "opentelemetry_0_23",
     feature = "opentelemetry_0_24",
     feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
 ))]
 use opentelemetry::KeyValue;
 use opentelemetry::{global, metrics::MetricsError};
@@ -136,6 +137,7 @@ fn sanitize_string(s: &str) -> String {
     // feature = "opentelemetry_0_23",
     feature = "opentelemetry_0_24",
     feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
 ))]
 pub(crate) fn kv_map_normalize_k_v(kv: &KeyValue) -> (String, String) {
     (
@@ -150,6 +152,7 @@ pub(crate) fn kv_map_normalize_k_v(kv: &KeyValue) -> (String, String) {
     // feature = "opentelemetry_0_23",
     feature = "opentelemetry_0_24",
     feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
 ))]
 pub(crate) fn kv_map_k(kv: &KeyValue) -> String {
     kv.key.to_string()

--- a/src/opentelemetry.rs
+++ b/src/opentelemetry.rs
@@ -4,6 +4,17 @@
 #[macro_export]
 macro_rules! import_opentelemetry {
     () => {
+        #[cfg(feature = "opentelemetry_0_26")]
+        #[allow(unused_imports)]
+        use opentelemetry_0_26_pkg as opentelemetry;
+
+        #[cfg(feature = "opentelemetry_0_26")]
+        use opentelemetry_sdk_0_26_pkg as opentelemetry_sdk;
+
+        #[cfg(feature = "opentelemetry_0_26")]
+        #[allow(unused_imports)]
+        use opentelemetry_resourcedetector_gcp_rust_0_13_pkg as opentelemetry_resourcedetector_gcp_rust;
+
         #[cfg(feature = "opentelemetry_0_25")]
         #[allow(unused_imports)]
         use opentelemetry_0_25_pkg as opentelemetry;

--- a/src/opentelemetry.rs
+++ b/src/opentelemetry.rs
@@ -4,6 +4,17 @@
 #[macro_export]
 macro_rules! import_opentelemetry {
     () => {
+        #[cfg(feature = "opentelemetry_0_27")]
+        #[allow(unused_imports)]
+        use opentelemetry_0_27_pkg as opentelemetry;
+
+        #[cfg(feature = "opentelemetry_0_27")]
+        use opentelemetry_sdk_0_27_pkg as opentelemetry_sdk;
+
+        #[cfg(feature = "opentelemetry_0_27")]
+        #[allow(unused_imports)]
+        use opentelemetry_resourcedetector_gcp_rust_0_14_pkg as opentelemetry_resourcedetector_gcp_rust;
+
         #[cfg(feature = "opentelemetry_0_26")]
         #[allow(unused_imports)]
         use opentelemetry_0_26_pkg as opentelemetry;

--- a/src/tests/test_cloud_monitoring.rs
+++ b/src/tests/test_cloud_monitoring.rs
@@ -23,7 +23,11 @@ mod tests {
     use prost::Message;
     use std::collections::HashMap;
 
-    #[cfg(any(feature = "opentelemetry_0_25", feature = "opentelemetry_0_26",))]
+    #[cfg(any(
+        feature = "opentelemetry_0_25",
+        feature = "opentelemetry_0_26",
+        feature = "opentelemetry_0_27",
+    ))]
     fn my_unit() -> String {
         "myunit".to_string()
     }
@@ -52,8 +56,17 @@ mod tests {
         let histogram = meter
             .f64_histogram("myhistogram")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let histogram = histogram.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let histogram = histogram.build();
         for i in 0..10_000 {
             histogram.record(
                 i as f64,
@@ -304,8 +317,17 @@ mod tests {
         let histogram = meter
             .f64_histogram("my_single_bucket_histogram")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let histogram = histogram.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let histogram = histogram.build();
         for i in 0..10_000 {
             histogram.record(
                 i as f64,
@@ -504,8 +526,17 @@ mod tests {
         let updowncounter = meter
             .f64_up_down_counter("myupdowncounter")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let updowncounter = updowncounter.build();
         updowncounter.add(
             45.6,
             &[
@@ -662,8 +693,17 @@ mod tests {
         let updowncounter = meter
             .i64_up_down_counter("myupdowncounter")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let updowncounter = updowncounter.build();
         updowncounter.add(
             45,
             &[
@@ -816,7 +856,7 @@ mod tests {
             "metric-demo",
         )]));
         let meter = metrics_provider.meter("test_cloud_monitoring");
-        let _updowncounter = meter
+        let updowncounter = meter
             .i64_observable_up_down_counter("myobservablecounter")
             .with_callback(|result| {
                 result.observe(
@@ -829,8 +869,17 @@ mod tests {
                 );
             })
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let _updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let _updowncounter = updowncounter.build();
         metrics_provider.force_flush().unwrap();
         let res = calls.read().await;
         let create_metric_descriptor = res
@@ -975,7 +1024,7 @@ mod tests {
             "metric-demo",
         )]));
         let meter = metrics_provider.meter("test_cloud_monitoring");
-        let _updowncounter = meter
+        let updowncounter = meter
             .f64_observable_up_down_counter("myobservablecounter")
             .with_callback(|result| {
                 result.observe(
@@ -988,8 +1037,17 @@ mod tests {
                 );
             })
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let _updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let _updowncounter = updowncounter.build();
         metrics_provider.force_flush().unwrap();
         let res = calls.read().await;
         let create_metric_descriptor = res
@@ -1136,7 +1194,7 @@ mod tests {
             "metric-demo",
         )]));
         let meter = metrics_provider.meter("test_cloud_monitoring");
-        let _updowncounter = meter
+        let updowncounter = meter
             .u64_observable_counter("myobservablecounter")
             .with_callback(|result| {
                 result.observe(
@@ -1149,8 +1207,17 @@ mod tests {
                 );
             })
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let _updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let _updowncounter = updowncounter.build();
         metrics_provider.force_flush().unwrap();
         let res = calls.read().await;
         let create_metric_descriptor = res
@@ -1297,7 +1364,7 @@ mod tests {
             "metric-demo",
         )]));
         let meter = metrics_provider.meter("test_cloud_monitoring");
-        let _updowncounter = meter
+        let updowncounter = meter
             .f64_observable_counter("myobservablecounter")
             .with_callback(|result| {
                 result.observe(
@@ -1310,8 +1377,17 @@ mod tests {
                 );
             })
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let _updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let _updowncounter = updowncounter.build();
         metrics_provider.force_flush().unwrap();
         let res = calls.read().await;
         let create_metric_descriptor = res
@@ -1460,7 +1536,7 @@ mod tests {
             "metric-demo",
         )]));
         let meter = metrics_provider.meter("test_cloud_monitoring");
-        let _updowncounter = meter
+        let updowncounter = meter
             .u64_observable_gauge("myobservablegauge")
             .with_callback(|result| {
                 result.observe(
@@ -1473,8 +1549,17 @@ mod tests {
                 );
             })
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let _updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let _updowncounter = updowncounter.build();
         metrics_provider.force_flush().unwrap();
         let res = calls.read().await;
         let create_metric_descriptor = res
@@ -1619,7 +1704,7 @@ mod tests {
             "metric-demo",
         )]));
         let meter = metrics_provider.meter("test_cloud_monitoring");
-        let _updowncounter = meter
+        let updowncounter = meter
             .f64_observable_gauge("myobservablegauge")
             .with_callback(|result| {
                 result.observe(
@@ -1632,8 +1717,17 @@ mod tests {
                 );
             })
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let _updowncounter = updowncounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let _updowncounter = updowncounter.build();
         metrics_provider.force_flush().unwrap();
         let res = calls.read().await;
         let create_metric_descriptor = res
@@ -1783,8 +1877,17 @@ mod tests {
         let mycounter = meter
             .u64_counter("mycounter")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let mycounter = mycounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let mycounter = mycounter.build();
 
         mycounter.add(
             45,
@@ -1943,8 +2046,17 @@ mod tests {
         let mycounter = meter
             .f64_counter("mycounter")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let mycounter = mycounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let mycounter = mycounter.build();
 
         mycounter.add(
             45.0,
@@ -2105,8 +2217,17 @@ mod tests {
         let mycounter = meter
             .u64_counter("mycounter")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let mycounter = mycounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let mycounter = mycounter.build();
 
         mycounter.add(12, &[KeyValue::new("1some.invalid$\\key", "value")]);
         metrics_provider.force_flush().unwrap();
@@ -2245,8 +2366,17 @@ mod tests {
         let mycounter = meter
             .u64_counter("mycounter")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let mycounter = mycounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let mycounter = mycounter.build();
 
         mycounter.add(
             12,
@@ -2428,8 +2558,17 @@ mod tests {
         let mycounter = meter
             .u64_counter("mycounter")
             .with_description("foo")
-            .with_unit(my_unit())
-            .init();
+            .with_unit(my_unit());
+        #[cfg(any(
+            feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
+            feature = "opentelemetry_0_25",
+            feature = "opentelemetry_0_26",
+        ))]
+        let mycounter = mycounter.init();
+        #[cfg(any(feature = "opentelemetry_0_27",))]
+        let mycounter = mycounter.build();
 
         mycounter.add(
             45,

--- a/src/tests/test_cloud_monitoring.rs
+++ b/src/tests/test_cloud_monitoring.rs
@@ -23,7 +23,7 @@ mod tests {
     use prost::Message;
     use std::collections::HashMap;
 
-    #[cfg(any(feature = "opentelemetry_0_25",))]
+    #[cfg(any(feature = "opentelemetry_0_25", feature = "opentelemetry_0_26",))]
     fn my_unit() -> String {
         "myunit".to_string()
     }


### PR DESCRIPTION
As title. I only tested this with opentelemetry `0.27.1`, but the code should also compile fine with `0.26.0` so  I am quite certain that also works.

I made two decisions which could be considered debatable:

* Returning the default temporality for the new `temporality` function, because I believe that in `GCPMetricsExporter` we do not have any other relevant data to decide what the temporality of the exported metrics will be
* For `global::handle_error` being removed, I replaced that by `tracing::ẁarn`, which I feel is the closest to the earlier `eprintln` and also makes it possible to trace the logs in a nice way. And I made them `warning` level because not all of the calls lead to real errors.